### PR TITLE
Object id fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ sync.all = function(query, options, fn) {
     options = {};
   }
 
-  fixQuery(query);
+  fixQuery.call(this, query);
 
   debug('getting all %j with options %j', query, options);
   this.db.find(query, options, function(err, models) {
@@ -75,10 +75,10 @@ sync.get = function(query, options, fn) {
   }
 
   var action = 'findOne';
-  if ('string' == typeof query) 
+  if ('string' == typeof query)
     action = 'findById';
   else
-    fixQuery(query);
+    fixQuery.call(this, query);
 
   debug('getting %j using %s with %j options...', query, action, options);
   db[action](query, options, function(err, model) {
@@ -94,7 +94,7 @@ sync.get = function(query, options, fn) {
  */
 
 sync.removeAll = function(query, fn) {
-  fixQuery(query);
+  fixQuery.call(this, query);
   this.db.remove(query, fn);
 };
 
@@ -189,8 +189,15 @@ sync.remove = function(query, fn) {
 };
 
 function fixQuery(query) {
+  // Fix monk's query casting
+  var Model;
+  if(this.model)
+    Model = this.model;
+  else
+    Model = this;
+
   for(var key in query) {
-    if(typeof query[key].toHexString == 'function')
-      query[key] = query[key].toHexString();
+    if(Model.attrs[key] && Model.attrs[key].references)
+      query[key] = Model.db.id(query[key]);
   }
 }

--- a/index.js
+++ b/index.js
@@ -107,6 +107,7 @@ sync.save = function(fn) {
       self = this;
 
   debug('saving... %j', json);
+  fixQuery.call(this, json);
   this.model.db.insert(json, function(err, doc) {
     if(err) {
       // Check for duplicate index
@@ -144,6 +145,8 @@ sync.update = function(fn) {
     sid = id.toHexString();
   else
     sid = id;
+
+  changed = fixQuery.call(this, changed);
 
   debug('updating %s and settings %j', id, changed);
   db.findAndModify({ _id : sid }, { $set : changed }, function(err, doc) {
@@ -200,4 +203,6 @@ function fixQuery(query) {
     if(Model.attrs[key] && Model.attrs[key].references)
       query[key] = Model.db.id(query[key]);
   }
+
+  return query;
 }


### PR DESCRIPTION
By adding the `references` option to a field, we can see if we should convert the type to a BSON Id, thus avoiding the stupid bad BSON Element Bug. Also, converts `_id` to string for the same damn bug.
