### PR TITLE
Specify the collection for a model

### DIFF
--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -14,8 +14,13 @@ var debug = require('debug')('modella:mongo'),
 module.exports = function(url) {
   var mongo = require('mongoskin').db(url, {w: 1}, function() { });
 
+  // Use alternate collection name, defaults to modelName
   return function(Model) {
-    var db = mongo.collection(Model.modelName);
+    return ('string' == typeof Model) ? plugin.bind(null, Model) : plugin(Model.modelName, Model);
+  };
+
+  function plugin(collection, Model) {
+    var db = mongo.collection(collection);
     Model.db = db;
 
     db.open(function(err, col) {
@@ -125,5 +130,5 @@ module.exports = function(url) {
       if(typeof query == 'object' && query._id && typeof query._id == 'string')
         query._id = db.id(query._id);
     }
-  };
+  }
 };

--- a/test/test.js
+++ b/test/test.js
@@ -29,6 +29,18 @@ describe("Modella-Mongo", function() {
     col.remove({}, done);
   });
 
+  describe("collection", function() {
+    it("sets the collection name", function() {
+      var Foo = modella('Foo').use(mongo('bar'));
+      expect(Foo.db.collection.collectionName).to.be('bar');
+    });
+
+    it("sets a default collection name", function() {
+      var Baz = modella('Baz').use(mongo);
+      expect(Baz.db.collection.collectionName).to.be('Baz');
+    });
+  });
+
   describe("sync layer operations", function() {
     it("defines the required sync layer operations", function() {
       expect(User.save).to.be.a('function');


### PR DESCRIPTION
ref #7

It'd be helpful to be able to set the collection for a given model, I thought this way could work & wasn't too disruptive:

``` js
var mongo = require('modella-mongo')('localhost/myapp')
var User = model('User')

// db.User
User.use(mongo)

// db.app_users
User.use(mongo('app_users'))
```

Thoughts?
