### PR TITLE
add detection for toMongo method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 script/
 coverage.html
+.tern-port

--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -52,7 +52,13 @@ module.exports = function(url) {
 
     Model.save = function(cb) {
       var self = this;
-      return db.insert(this.toJSON(), function(err, docs) {
+      var doc;
+      if (this.toMongo && typeof this.toMongo === 'function') {
+        doc = this.toMongo();
+      } else {
+        doc = this.toJSON();
+      }
+      return db.insert(doc, function(err, docs) {
         var doc = docs ? docs[0] : null;
         if(err) {
           // Check for duplicate index


### PR DESCRIPTION
First tried to detect method `model#toMongo()` to get the document used
for saving. This allows `model#toJSON()` to be overridden to hide
hidden/unneeded fields without messing up the database document
structure.

`model#toJSON()` is used as the fallback if the model prototype does not
have a `toMongo()` method.
