### PR TITLE
use $unset in update queries when the attribute has been unset on the model

### DIFF
--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -168,17 +168,6 @@ module.exports = function(url) {
         }
       });
 
-      // loop through the model's attributes and see if there is
-      // anything missing, if so, use $unset to remove it from the
-      // database (prevents `undefined` attributes from being cast to
-      // `null`
-      Object.keys(Model.attrs).forEach(function(attr) {
-        if (self.attrs[attr] === undefined) {
-          if (!updateDoc.$unset) updateDoc.$unset = {};
-          updateDoc.$unset[attr] = "";
-        }
-      });
-
       if (self.errors.length) return cb(new Error(self.errors[0].message));
 
       return db.findAndModify({_id: id}, {}, updateDoc, {new: true}, function(err, doc) {

--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -115,6 +115,15 @@ module.exports = function(url) {
       // loop through each changed key to see if it has been configured as "atomic"
       Object.keys(changed).forEach(function(changedKey) {
         var options = Model.attrs[changedKey];
+
+        // if the value is actually *set* to undefined, then we want
+        // to $unset it in the database
+        if (changed[changedKey] === undefined) {
+          if (!updateDoc.$unset) updateDoc.$unset = {};
+          updateDoc.$unset[changedKey] = "";
+          return;
+        }
+
         if (options.atomic) {
           // if atomic, try parsing it as a number
           var numString = changed[changedKey].toString();
@@ -156,6 +165,17 @@ module.exports = function(url) {
           }
           if (!updateDoc.$set) updateDoc.$set = {};
           updateDoc.$set[changedKey] = changed[changedKey];
+        }
+      });
+
+      // loop through the model's attributes and see if there is
+      // anything missing, if so, use $unset to remove it from the
+      // database (prevents `undefined` attributes from being cast to
+      // `null`
+      Object.keys(Model.attrs).forEach(function(attr) {
+        if (self.attrs[attr] === undefined) {
+          if (!updateDoc.$unset) updateDoc.$unset = {};
+          updateDoc.$unset[attr] = "";
         }
       });
 

--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -145,7 +145,7 @@ module.exports = function(url) {
           }
           // set the old atomic value to the new value
           self.oldAtomics[changedKey] = changed[changedKey];
-        } else if (self.unset[changedKey] === true) {
+        } else if (self.unsetAttrs[changedKey] === true) {
           if (!updateDoc.$unset) updateDoc.$unset = {};
           updateDoc.$unset[changedKey] = "";
           delete self.unset[changedKey];

--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -116,14 +116,6 @@ module.exports = function(url) {
       Object.keys(changed).forEach(function(changedKey) {
         var options = Model.attrs[changedKey];
 
-        // if the value is actually *set* to undefined, then we want
-        // to $unset it in the database
-        if (changed[changedKey] === undefined) {
-          if (!updateDoc.$unset) updateDoc.$unset = {};
-          updateDoc.$unset[changedKey] = "";
-          return;
-        }
-
         if (options.atomic) {
           // if atomic, try parsing it as a number
           var numString = changed[changedKey].toString();
@@ -153,6 +145,10 @@ module.exports = function(url) {
           }
           // set the old atomic value to the new value
           self.oldAtomics[changedKey] = changed[changedKey];
+        } else if (self.unset[changedKey] === true) {
+          if (!updateDoc.$unset) updateDoc.$unset = {};
+          updateDoc.$unset[changedKey] = "";
+          delete self.unset[changedKey];
         } else {
           // check for certain types to see if we need to convert from strings before updating
           if (options.type) {

--- a/test/test.js
+++ b/test/test.js
@@ -298,7 +298,6 @@ describe("Modella-Mongo", function() {
           // load an incomplete user record
           User.get(user.primary().toHexString(), {fields: {age: true}}, function(err, user2) {
             user2.age(user2.age() + 1);
-            console.log(user2);
             user2.save(function(err) {
               expect(err).to.not.be.ok();
               expect(user2.email()).to.be("eddie@eddiecorp.com");

--- a/test/test.js
+++ b/test/test.js
@@ -272,7 +272,7 @@ describe("Modella-Mongo", function() {
         });
       });
 
-      it("uses $uset to remove undefined properties", function(done) {
+      it("uses $unset to remove undefined properties", function(done) {
         var user = new User({name: 'Eddie', age: 30, email: "eddie@eddiecorp.com"});
         user.save(function(err) {
           expect(err).to.not.be.ok();
@@ -286,6 +286,25 @@ describe("Modella-Mongo", function() {
             expect(user.email() === undefined).to.be(true);
             expect(user.password()).to.be('password');
             done();
+          });
+        });
+      });
+
+      it("does not $unset when a value is not explicitly set to `undefined`", function(done) {
+        var user = new User({name: 'Eddie', age: 30, email: "eddie@eddiecorp.com"});
+        user.save(function(err) {
+          expect(err).to.not.be.ok();
+          expect(user.email()).to.be("eddie@eddiecorp.com");
+          // load an incomplete user record
+          User.get(user.primary().toHexString(), {fields: {age: true}}, function(err, user2) {
+            user2.age(user2.age() + 1);
+            console.log(user2);
+            user2.save(function(err) {
+              expect(err).to.not.be.ok();
+              expect(user2.email()).to.be("eddie@eddiecorp.com");
+              expect(user2.age()).to.be(31);
+              done();
+            });
           });
         });
       });

--- a/test/test.js
+++ b/test/test.js
@@ -272,6 +272,24 @@ describe("Modella-Mongo", function() {
         });
       });
 
+      it("uses $uset to remove undefined properties", function(done) {
+        var user = new User({name: 'Eddie', age: 30, email: "eddie@eddiecorp.com"});
+        user.save(function(err) {
+          expect(err).to.not.be.ok();
+          expect(user.email()).to.be("eddie@eddiecorp.com");
+          user.set({
+            email: undefined,
+            password: 'password'
+          });
+          user.save(function(err) {
+            expect(err).to.not.be.ok();
+            expect(user.email() === undefined).to.be(true);
+            expect(user.password()).to.be('password');
+            done();
+          });
+        });
+      });
+
       it("refuses to update a non-number atomic property", function(done) {
         var user = new AtomicUser({name: 'Eddie', age: 30});
         user.save(function(err) {

--- a/test/test.js
+++ b/test/test.js
@@ -24,7 +24,7 @@ var AtomicUser = modella('AtomicUser')
   .attr('email', {unique: true})
   .attr('password');
 
-var Ticket = modella('ticket')
+var Ticket = modella('Ticket')
   .attr('_id')
   .attr('created', {type: 'date'})
   .attr('viewed', {type: Date})
@@ -46,12 +46,15 @@ var user = new User();
 
 var col = db.collection("User");
 var atomiccol = db.collection("AtomicUser");
+var ticketcol = db.collection("Ticket");
 
 
 describe("Modella-Mongo", function() {
   before(function(done) {
     col.remove({}, function() {
-      atomiccol.remove({}, done);
+      ticketcol.remove({}, function() {
+        atomiccol.remove({}, done);
+      });
     });
   });
 


### PR DESCRIPTION
Use the $unset update modifier when encountering properties that have been unset on the model

The unit tests for this will fail unless you are using the paulbdavis/modella#unset version of the modella module [PR for the unset feature](https://github.com/modella/modella/pull/41)

EDIT: Seems I was wrong  about the tests not passing
