### PR TITLE
Date checker

### DIFF
--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -52,7 +52,20 @@ module.exports = function(url) {
 
     Model.save = function(cb) {
       var self = this;
-      return db.insert(this.toJSON(), function(err, docs) {
+      var jsonDoc = this.toJSON();
+      Object.keys(jsonDoc).forEach(function(attr) {
+        var options = Model.attrs[attr];
+        // check for typoes that need to be parsed from strings into
+        // an object now that modella is recursively calling toJSON
+        if (options.type) {
+          if (options.type === 'date' || options.type === Date) {
+            if ('string' === typeof jsonDoc[attr]) {
+              jsonDoc[attr] = new Date(jsonDoc[attr]);
+            }
+          }
+        }
+      });
+      return db.insert(jsonDoc, function(err, docs) {
         var doc = docs ? docs[0] : null;
         if(err) {
           // Check for duplicate index

--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -117,6 +117,12 @@ module.exports = function(url) {
           // set the old atomic value to the new value
           self.oldAtomics[changedKey] = changed[changedKey];
         } else {
+          // check for certain types to see if we need to convert from strings before updating
+          if (options.type) {
+            if (options.type === 'date' || options.type === Date) {
+              if ('string' === typeof changed[changedKey]) changed[changedKey] = new Date(changed[changedKey]);
+            }
+          }
           if (!updateDoc.$set) updateDoc.$set = {};
           updateDoc.$set[changedKey] = changed[changedKey];
         }


### PR DESCRIPTION
Check for `{type: 'date'}` and `{type: Date}` in the attr options when inserting/updating and parse it as a `Date` object if the value is a string.

This counter's the new recursive `toJSON` call in modella, causing mongo to store `Date` values as strings rather than `ISODate` objects
