### PR TITLE
Date checker

### DIFF
--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -52,7 +52,20 @@ module.exports = function(url) {
 
     Model.save = function(cb) {
       var self = this;
-      return db.insert(this.toJSON(), function(err, docs) {
+      var jsonDoc = this.toJSON();
+      Object.keys(jsonDoc).forEach(function(attr) {
+        var options = Model.attrs[attr];
+        // check for typoes that need to be parsed from strings into
+        // an object now that modella is recursively calling toJSON
+        if (options.type) {
+          if (options.type === 'date' || options.type === Date) {
+            if ('string' === typeof jsonDoc[attr]) {
+              jsonDoc[attr] = new Date(jsonDoc[attr]);
+            }
+          }
+        }
+      });
+      return db.insert(jsonDoc, function(err, docs) {
         var doc = docs ? docs[0] : null;
         if(err) {
           // Check for duplicate index

--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -117,6 +117,12 @@ module.exports = function(url) {
           // set the old atomic value to the new value
           self.oldAtomics[changedKey] = changed[changedKey];
         } else {
+          // check for certain types to see if we need to convert from strings before updating
+          if (options.type) {
+            if (options.type === 'date' || options.type === Date) {
+              if ('string' === typeof changed[changedKey]) changed[changedKey] = new Date(changed[changedKey]);
+            }
+          }
           if (!updateDoc.$set) updateDoc.$set = {};
           updateDoc.$set[changedKey] = changed[changedKey];
         }

--- a/test/test.js
+++ b/test/test.js
@@ -24,9 +24,16 @@ var AtomicUser = modella('AtomicUser')
   .attr('email', {unique: true})
   .attr('password');
 
+var Ticket = modella('ticket')
+  .attr('_id')
+  .attr('created', {type: 'date'})
+  .attr('viewed', {type: Date})
+  .attr('message', {type: 'string'});
+
 
 User.use(mongo);
 AtomicUser.use(mongo);
+Ticket.use(mongo);
 
 /**
  * Initialize
@@ -85,6 +92,21 @@ describe("Modella-Mongo", function() {
           done();
         });
       });
+
+      it("parses a string as a date if the type is set to `'date'` or `Date`", function(done) {
+        var ticket = new Ticket({
+          created: '2014-01-01',
+          viewed: '2014-01-02',
+          message: 'Foo to you sir'
+        });
+
+        ticket.save(function(err) {
+          expect(ticket.created() instanceof Date).to.be(true);
+          expect(ticket.viewed() instanceof Date).to.be(true);
+          done();
+        });
+      });
+
     });
 
     describe("update", function() {
@@ -116,6 +138,24 @@ describe("Modella-Mongo", function() {
               expect(u).to.have.property('age', 30);
               done();
             });
+          });
+        });
+      });
+
+      it("parses a string as a date if the type is set to `'date'` or `Date`", function(done) {
+        var ticket = new Ticket({
+          created: '2014-01-01',
+          viewed: '2014-01-02',
+          message: 'Foo to you sir'
+        });
+
+        ticket.save(function(err) {
+          expect(ticket.created() instanceof Date).to.be(true);
+          expect(ticket.viewed() instanceof Date).to.be(true);
+          ticket.viewed('2014-01-03');
+          ticket.save(function(err) {
+            expect(ticket.viewed() instanceof Date).to.be(true);
+            done();
           });
         });
       });


### PR DESCRIPTION
Check for `{type: 'date'}` and `{type: Date}` in the attr options when inserting/updating and parse it as a `Date` object if the value is a string.

This counter's the new recursive `toJSON` call in modella, causing mongo to store `Date` values as strings rather than `ISODate` objects
