### PR TITLE
Update mongoskin

### DIFF
--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -50,10 +50,13 @@ module.exports = function(url) {
     });
 
     Model.once('initialize', function() {
+      var indexCb = function(err) {
+        if (err) throw err;
+      };
       for(var attr in Model.attrs) {
         if (Model.attrs.hasOwnProperty(attr)) {
           var options = Model.attrs[attr];
-          if (options.unique) Model.index(attr, { w: 0, unique: true, sparse: true });
+          if (options.unique) Model.index(attr, { w: 0, unique: true, sparse: true }, indexCb);
         }
       }
     });

--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -32,9 +32,8 @@ module.exports = function(url) {
       if (err) throw err;
       mquery(Model, db._native);
       maggregate(Model, db._native);
-      Model.db = {
-        collection: db._native
-      };
+      Model.db = db;
+      db.collection = db._native;
       db.id = mongoskin.ObjectID;
     });
 

--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -4,6 +4,7 @@
  */
 
 var debug = require('debug')('modella:mongo'),
+    mongoskin = require('mongoskin'),
     mquery = require('./mquery'),
     maggregate = require('./maggregate'),
     sync = {};
@@ -13,21 +14,28 @@ var debug = require('debug')('modella:mongo'),
 var FLOAT_REGEXP = /[0-9]*\.[0-9]*/;
 var SCIENTIFIC_REGEXP = /[0-9.]+e[0-9]+/;
 
+var URL_REGEXP = /^mongodb:\/\//;
 /**
  * Export `Mongo`
  */
 
 module.exports = function(url) {
-  var mongo = require('mongoskin').db(url, {w: 1}, function() { });
+  if (!URL_REGEXP.test(url)) {
+    url = 'mongodb://' + url;
+  }
+  var mongo = mongoskin.db(url, {w: 1}, function() { });
 
   function plugin(collection, Model) {
     var db = mongo.collection(collection);
-    Model.db = db;
 
     db.open(function(err) {
       if (err) throw err;
-      mquery(Model, db.collection);
-      maggregate(Model, db.collection);
+      mquery(Model, db._native);
+      maggregate(Model, db._native);
+      Model.db = {
+        collection: db._native
+      };
+      db.id = mongoskin.ObjectID;
     });
 
     Model.index = db.ensureIndex.bind(db);

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
   "dependencies": {
     "batch": "~0.2.1",
     "debug": "~0.7.0",
-    "mquery": "0.3.3",
-    "maggregate": "~0.1.0",
-    "mongoskin": "0.6.1"
+    "maggregate": "^0.2.1",
+    "mongoskin": "^1.4.4",
+    "mquery": "^1.2.1"
   },
   "devDependencies": {
     "async": "~0.9.0",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
   "dependencies": {
     "batch": "~0.2.1",
     "debug": "~0.7.0",
-    "maggregate": "^0.2.1",
-    "mongoskin": "^1.4.4",
-    "mquery": "^1.2.1"
+    "maggregate": "~0.2.1",
+    "mongoskin": "~1.4.4",
+    "mquery": "~1.2.1"
   },
   "devDependencies": {
     "async": "~0.9.0",

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,7 @@
 var modella = require('modella'),
     mongo = require('../')('localhost:27017/modella-mongo'),
     mongoskin = require('mongoskin'),
-    db = require('mongoskin').db('localhost:27017/modella-mongo', {w: 1}),
+    db = require('mongoskin').db('mongodb://localhost:27017/modella-mongo', {w: 1}),
     mquery = require('mquery'),
     maggregate = require('maggregate'),
     Batch = require('batch'),


### PR DESCRIPTION
Update mongoskin to version 1.4.4

The version that was being used did not properly handle connecting to a mongo replica set.

mquery and maggregate were also updated
