### PR TITLE
Parse objectid

### DIFF
--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -73,7 +73,7 @@ module.exports = function(url) {
               jsonDoc[attr] = new Date(jsonDoc[attr]);
             }
           }
-          if (options.type === mongo.ObjectID) {
+          if (options.type === mongoskin.ObjectID) {
             if ('string' === typeof jsonDoc[attr]) {
               jsonDoc[attr] = db.id(jsonDoc[attr]);
             }
@@ -150,7 +150,7 @@ module.exports = function(url) {
             if (options.type === 'date' || options.type === Date) {
               if ('string' === typeof changed[changedKey]) changed[changedKey] = new Date(changed[changedKey]);
             }
-            if (options.type === mongo.ObjectID) {
+            if (options.type === mongoskin.ObjectID) {
               if ('string' === typeof changed[changedKey]) changed[changedKey] = db.id(changed[changedKey]);
             }
           }

--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -73,6 +73,11 @@ module.exports = function(url) {
               jsonDoc[attr] = new Date(jsonDoc[attr]);
             }
           }
+          if (options.type === mongo.ObjectID) {
+            if ('string' === typeof jsonDoc[attr]) {
+              jsonDoc[attr] = db.id(jsonDoc[attr]);
+            }
+          }
         }
       });
       return db.insert(jsonDoc, function(err, docs) {
@@ -144,6 +149,9 @@ module.exports = function(url) {
           if (options.type) {
             if (options.type === 'date' || options.type === Date) {
               if ('string' === typeof changed[changedKey]) changed[changedKey] = new Date(changed[changedKey]);
+            }
+            if (options.type === mongo.ObjectID) {
+              if ('string' === typeof changed[changedKey]) changed[changedKey] = db.id(changed[changedKey]);
             }
           }
           if (!updateDoc.$set) updateDoc.$set = {};

--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -73,7 +73,7 @@ module.exports = function(url) {
               jsonDoc[attr] = new Date(jsonDoc[attr]);
             }
           }
-          if (options.type === mongoskin.ObjectID) {
+          if (options.type === mongoskin.ObjectID || options.type === 'ObjectId' || options.type === 'ObjectID') {
             if ('string' === typeof jsonDoc[attr]) {
               jsonDoc[attr] = db.id(jsonDoc[attr]);
             }
@@ -150,7 +150,7 @@ module.exports = function(url) {
             if (options.type === 'date' || options.type === Date) {
               if ('string' === typeof changed[changedKey]) changed[changedKey] = new Date(changed[changedKey]);
             }
-            if (options.type === mongoskin.ObjectID) {
+            if (options.type === mongoskin.ObjectID || options.type === 'ObjectId' || options.type === 'ObjectID') {
               if ('string' === typeof changed[changedKey]) changed[changedKey] = db.id(changed[changedKey]);
             }
           }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "expect.js": "*",
     "mocha": "*",
     "mocha-lcov-reporter": "0.0.1",
-    "modella": "0.2.0"
+    "modella": "~0.2.9"
   },
   "main": "index"
 }

--- a/test/test.js
+++ b/test/test.js
@@ -28,7 +28,8 @@ var Ticket = modella('ticket')
   .attr('_id')
   .attr('created', {type: 'date'})
   .attr('viewed', {type: Date})
-  .attr('message', {type: 'string'});
+  .attr('message', {type: 'string'})
+  .attr('creatorId', {type: mongoskin.ObjectID});
 
 
 User.use(mongo);
@@ -107,6 +108,24 @@ describe("Modella-Mongo", function() {
         });
       });
 
+      it("parses a string as an ObjectID if the type is set to `ObjectID`", function(done) {
+        var oid = new mongoskin.ObjectID();
+        var ticket = new Ticket({
+          created: '2014-01-01',
+          viewed: '2014-01-02',
+          message: 'Foo to you sir',
+          creatorId: oid.toHexString()
+        });
+
+        ticket.save(function(err) {
+          expect(ticket.created() instanceof Date).to.be(true);
+          expect(ticket.viewed() instanceof Date).to.be(true);
+          expect(ticket.creatorId() instanceof mongoskin.ObjectID).to.be(true);
+          expect(ticket.creatorId().equals(oid)).to.be(true);
+          done();
+        });
+      });
+
     });
 
     describe("update", function() {
@@ -155,6 +174,32 @@ describe("Modella-Mongo", function() {
           ticket.viewed('2014-01-03');
           ticket.save(function(err) {
             expect(ticket.viewed() instanceof Date).to.be(true);
+            done();
+          });
+        });
+      });
+
+      it("parses a string as an ObjectID if the type is set to `ObjectID`", function(done) {
+        var oid = new mongoskin.ObjectID();
+        var ticket = new Ticket({
+          created: '2014-01-01',
+          viewed: '2014-01-02',
+          message: 'Foo to you sir',
+          creatorId: oid.toHexString()
+        });
+
+        ticket.save(function(err) {
+          expect(ticket.created() instanceof Date).to.be(true);
+          expect(ticket.viewed() instanceof Date).to.be(true);
+          expect(ticket.creatorId() instanceof mongoskin.ObjectID).to.be(true);
+          expect(ticket.creatorId().equals(oid)).to.be(true);
+          ticket.viewed('2014-01-03');
+          var newOid = new mongoskin.ObjectID();
+          ticket.creatorId(newOid.toHexString());
+          ticket.save(function(err) {
+            expect(ticket.viewed() instanceof Date).to.be(true);
+            expect(ticket.creatorId() instanceof mongoskin.ObjectID).to.be(true);
+            expect(ticket.creatorId().equals(newOid)).to.be(true);
             done();
           });
         });

--- a/test/test.js
+++ b/test/test.js
@@ -29,7 +29,9 @@ var Ticket = modella('ticket')
   .attr('created', {type: 'date'})
   .attr('viewed', {type: Date})
   .attr('message', {type: 'string'})
-  .attr('creatorId', {type: mongoskin.ObjectID});
+  .attr('creatorId', {type: mongoskin.ObjectID})
+  .attr('responderId', {type: 'ObjectId'})
+  .attr('fixId', {type: 'ObjectID'});
 
 
 User.use(mongo);
@@ -109,19 +111,28 @@ describe("Modella-Mongo", function() {
       });
 
       it("parses a string as an ObjectID if the type is set to `ObjectID`", function(done) {
-        var oid = new mongoskin.ObjectID();
+        var creatorId = new mongoskin.ObjectID();
+        var responderId = new mongoskin.ObjectID();
+        var fixId = new mongoskin.ObjectID();
         var ticket = new Ticket({
           created: '2014-01-01',
           viewed: '2014-01-02',
           message: 'Foo to you sir',
-          creatorId: oid.toHexString()
+          creatorId: creatorId.toHexString(),
+          responderId: responderId.toHexString(),
+          fixId: fixId.toHexString()
         });
 
         ticket.save(function(err) {
           expect(ticket.created() instanceof Date).to.be(true);
           expect(ticket.viewed() instanceof Date).to.be(true);
           expect(ticket.creatorId() instanceof mongoskin.ObjectID).to.be(true);
-          expect(ticket.creatorId().equals(oid)).to.be(true);
+          expect(ticket.creatorId().equals(creatorId)).to.be(true);
+          expect(ticket.responderId() instanceof mongoskin.ObjectID).to.be(true);
+          expect(ticket.responderId().equals(responderId)).to.be(true);
+          expect(ticket.fixId() instanceof mongoskin.ObjectID).to.be(true);
+          expect(ticket.fixId().equals(fixId)).to.be(true);
+          ticket.viewed('2014-01-03');
           done();
         });
       });
@@ -180,26 +191,42 @@ describe("Modella-Mongo", function() {
       });
 
       it("parses a string as an ObjectID if the type is set to `ObjectID`", function(done) {
-        var oid = new mongoskin.ObjectID();
+        var creatorId = new mongoskin.ObjectID();
+        var responderId = new mongoskin.ObjectID();
+        var fixId = new mongoskin.ObjectID();
         var ticket = new Ticket({
           created: '2014-01-01',
           viewed: '2014-01-02',
           message: 'Foo to you sir',
-          creatorId: oid.toHexString()
+          creatorId: creatorId.toHexString(),
+          responderId: responderId.toHexString(),
+          fixId: fixId.toHexString()
         });
 
         ticket.save(function(err) {
           expect(ticket.created() instanceof Date).to.be(true);
           expect(ticket.viewed() instanceof Date).to.be(true);
           expect(ticket.creatorId() instanceof mongoskin.ObjectID).to.be(true);
-          expect(ticket.creatorId().equals(oid)).to.be(true);
+          expect(ticket.creatorId().equals(creatorId)).to.be(true);
+          expect(ticket.responderId() instanceof mongoskin.ObjectID).to.be(true);
+          expect(ticket.responderId().equals(responderId)).to.be(true);
+          expect(ticket.fixId() instanceof mongoskin.ObjectID).to.be(true);
+          expect(ticket.fixId().equals(fixId)).to.be(true);
           ticket.viewed('2014-01-03');
-          var newOid = new mongoskin.ObjectID();
-          ticket.creatorId(newOid.toHexString());
+          var newCreatorId = new mongoskin.ObjectID();
+          var newResponderId = new mongoskin.ObjectID();
+          var newFixId = new mongoskin.ObjectID();
+          ticket.creatorId(newCreatorId.toHexString());
+          ticket.responderId(newResponderId.toHexString());
+          ticket.fixId(newFixId.toHexString());
           ticket.save(function(err) {
             expect(ticket.viewed() instanceof Date).to.be(true);
             expect(ticket.creatorId() instanceof mongoskin.ObjectID).to.be(true);
-            expect(ticket.creatorId().equals(newOid)).to.be(true);
+            expect(ticket.creatorId().equals(newCreatorId)).to.be(true);
+            expect(ticket.responderId() instanceof mongoskin.ObjectID).to.be(true);
+            expect(ticket.responderId().equals(newResponderId)).to.be(true);
+            expect(ticket.fixId() instanceof mongoskin.ObjectID).to.be(true);
+            expect(ticket.fixId().equals(newFixId)).to.be(true);
             done();
           });
         });


### PR DESCRIPTION
Fix for the recursive toJSON calling in base modella which was
converting `ObjectID`s into strings before the save method is called.

Setting `{type: ObjectID}` on an attribute will cause any string value
passed in to be parsed into an `ObjectID`.
