### PR TITLE
make ObjectID constructor available on plugin before `use`ing it

### DIFF
--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -236,8 +236,13 @@ module.exports = function(url) {
   }
 
   // Use alternate collection name, defaults to modelName
-  return function(Model) {
+  var useFunction =  function(Model) {
     return ('string' === typeof Model) ? plugin.bind(null, Model) : plugin(Model.modelName, Model);
   };
+
+  useFunction.ObjectID = mongoskin.ObjectID;
+  useFunction.ObjectId = mongoskin.ObjectID;
+
+  return useFunction;
 
 };

--- a/test/test.js
+++ b/test/test.js
@@ -58,6 +58,11 @@ describe("Modella-Mongo", function() {
     });
   });
 
+  it('should provide access to the ObjectID constructor', function() {
+    expect(mongo.ObjectID).to.equal(mongoskin.ObjectID);
+    expect(mongo.ObjectId).to.equal(mongoskin.ObjectID);
+  });
+
   describe("collection", function() {
     it("sets the collection name", function() {
       var Foo = modella('Foo').use(mongo('bar'));


### PR DESCRIPTION
Easy access to the constructor for the new `type` options
